### PR TITLE
feat: add more relpaths for .git discovery

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -11,7 +11,7 @@ locals {
   )
 
   git_paths = compact([
-    for relpath in [".", "..", "../..", "../../..", "../../../..", "../../../../.."] :
+    for relpath in [".", "..", "../..", "../../..", "../../../..", "../../../../..", "../../../../../..", "../../../../../../..", "../../../../../../../..", "../../../../../../../../.."] :
     try(fileexists(format("%s/%s/.git/HEAD", path.root, relpath)), false) ? format("%s/%s", path.root, relpath) : null
   ])
 


### PR DESCRIPTION
When using with terragrunt, with depth folder tree, it fails to correctly detect git repo.

Added more items into array for "guessing" parent `.git` repo